### PR TITLE
Create play audio file block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+# Sphinx documentation
+docs/_build/
+
+# vim swap file
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Audio Blocks
+
+Blocks that deal with audio files
+
+## Blocks in this collection
+
+ * [PlayAudioFile](./docs/play_audio_file.md)
+
+## Requirements
+
+ * **simpleaudio** - For playing WAV format audio

--- a/docs/play_audio_file.md
+++ b/docs/play_audio_file.md
@@ -1,0 +1,14 @@
+# PlayAudioFile
+
+Plays an audio file from disk. Currently supports WAV files only.
+
+This block plays a WAV file from disk and notifies the incoming signal once the playing has completed. It makes use of the [LimitLock mixin](https://docs.n.io/blocks/block-mixins/limit-lock.html) to ensure that only one file gets played at a time.
+
+## Properties
+
+ * **Audio File Location** - The location of the audio file. If a relative path is given then it is interpreted from the working directory. To ensure a path relative from the project root use the `[[PROJECT_ROOT]]` environment variable.
+ * **Audio Queue Size** - The max number of audio files to queue up for playing. The block only plays one audio file at a time, this number represents the maximum number of files to queue up for playing. It is equivalent to the `max_locks` attribute of the LimitLock mixin.
+
+## Outputs
+
+ * The incoming signal is notified when the audio file has completed playing. If the file is not played (if it doesn't exist or the queue is full) then the signal is not notified.

--- a/play_audio_file_block.py
+++ b/play_audio_file_block.py
@@ -28,3 +28,7 @@ class PlayAudioFile(LimitLock, Block):
         self.logger.info("Playing simpleaudio obj {}".format(audio_obj))
         play = audio_obj.play()
         play.wait_done()
+
+    def stop(self):
+        simpleaudio.stop_all()
+        super().stop()

--- a/play_audio_file_block.py
+++ b/play_audio_file_block.py
@@ -1,0 +1,29 @@
+from os.path import isfile
+from nio import Block
+from nio.block.mixins import LimitLock
+from nio.properties import FileProperty, IntProperty
+import simpleaudio
+
+
+class PlayAudioFile(LimitLock, Block):
+
+    audio_file = FileProperty(title='Audio File Location', default='audio.wav')
+    max_locks = IntProperty(title='Audio Queue Size', default=5, advanced=True)
+
+    def process_signal(self, signal, input_id=None):
+        file_loc = self.audio_file(signal).value
+        if not isfile(file_loc):
+            self.logger.error(
+                "{} is not a valid file location".format(file_loc))
+            return
+        obj = simpleaudio.WaveObject.from_wave_file(file_loc)
+        self.execute_with_lock(
+            self._play_simpleaudio, self.max_locks(signal), obj)
+        # Notify the incoming signal once the audio has completed playing
+        return signal
+
+    def _play_simpleaudio(self, audio_obj):
+        """ Plays a simpleaudio object and waits for it to complete """
+        self.logger.info("Playing simpleaudio obj {}".format(audio_obj))
+        play = audio_obj.play()
+        play.wait_done()

--- a/play_audio_file_block.py
+++ b/play_audio_file_block.py
@@ -1,12 +1,13 @@
 from os.path import isfile
 from nio import Block
 from nio.block.mixins import LimitLock
-from nio.properties import FileProperty, IntProperty
+from nio.properties import FileProperty, IntProperty, VersionProperty
 import simpleaudio
 
 
 class PlayAudioFile(LimitLock, Block):
 
+    version = VersionProperty('0.1.0')
     audio_file = FileProperty(title='Audio File Location', default='audio.wav')
     max_locks = IntProperty(title='Audio Queue Size', default=5, advanced=True)
 

--- a/release.json
+++ b/release.json
@@ -1,0 +1,7 @@
+{
+  "nio/PlayAudioFile": {
+    "language": "Python",
+    "from_python": "play_audio_file_block/PlayAudioFile",
+    "url": "git://github.com/nio-blocks/audio.git"
+  }
+}

--- a/release.json
+++ b/release.json
@@ -1,7 +1,7 @@
 {
   "nio/PlayAudioFile": {
     "language": "Python",
-    "from_python": "play_audio_file_block/PlayAudioFile",
+    "from_python": "play_audio_file_block.PlayAudioFile",
     "url": "git://github.com/nio-blocks/audio.git"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+simpleaudio

--- a/spec.json
+++ b/spec.json
@@ -1,0 +1,11 @@
+{
+  "nio/PlayAudioFile": {
+    "description": "Play a WAV audio file located on disk",
+    "categories": [
+      "Notifications"
+    ],
+    "tags": "audio wav play",
+    "from_readme": "docs/play_audio_file.md",
+    "from_python": "play_audio_file_block/PlayAudioFile"
+  }
+}

--- a/spec.json
+++ b/spec.json
@@ -6,6 +6,6 @@
     ],
     "tags": "audio wav play",
     "from_readme": "docs/play_audio_file.md",
-    "from_python": "play_audio_file_block/PlayAudioFile"
+    "from_python": "play_audio_file_block.PlayAudioFile"
   }
 }

--- a/tests/test_play_audio_file_block.py
+++ b/tests/test_play_audio_file_block.py
@@ -1,0 +1,36 @@
+from nio import Signal
+from nio.testing.block_test_case import NIOBlockTestCase
+from unittest.mock import patch
+from ..play_audio_file_block import PlayAudioFile
+
+
+class TestPlayAudioFile(NIOBlockTestCase):
+
+    @patch(PlayAudioFile.__module__ + '.simpleaudio')
+    def test_plays_file(self, patch_audio):
+        blk = PlayAudioFile()
+        self.configure_block(blk, {
+            'audio_file': 'myfile.wav',
+        })
+        with patch(PlayAudioFile.__module__ + '.isfile') as isfile:
+            isfile.return_value = True
+            blk.process_signals([Signal({})])
+        isfile.assert_called_once_with('myfile.wav')
+        # We should load the wav file and then play it
+        wav_loader = patch_audio.WaveObject.from_wave_file
+        wav_loader.assert_called_once_with('myfile.wav')
+        wav_loader.return_value.play.assert_called_once_with()
+
+    @patch(PlayAudioFile.__module__ + '.simpleaudio')
+    def test_skips_missing_file(self, patch_audio):
+        blk = PlayAudioFile()
+        self.configure_block(blk, {
+            'audio_file': 'badfile.wav',
+        })
+        with patch(PlayAudioFile.__module__ + '.isfile') as isfile:
+            isfile.return_value = False
+            blk.process_signals([Signal({})])
+        isfile.assert_called_once_with('badfile.wav')
+        wav_loader = patch_audio.WaveObject.from_wave_file
+        # Make sure we don't try to create the audio object
+        self.assertEqual(wav_loader.call_count, 0)


### PR DESCRIPTION
This kicks off a repo for possible "audio" blocks. It just has a Play WAV File block for now, but some future ideas:
 * PlayAudioStream - take a base64 audio stream and play it - useful for combining with Watson or GCP Text-to-Speech blocks
 * WriteWAVFile - take a base64 audio stream and write to disk - useful for capturing speech from a microphone or something and saving it
 * additional audio format (e.g. MP3) support